### PR TITLE
`chrome-gnome-shell` was renamed to `gnome-browser-connector` in newer Fedora releases

### DIFF
--- a/vars/fedora-40.yml
+++ b/vars/fedora-40.yml
@@ -18,7 +18,7 @@ _service: gdm.service
 
 _yum:
   - { state: latest, name: "@gnome-desktop" }
-  - { state: latest, name: chrome-gnome-shell }
+  - { state: latest, name: gnome-browser-connector }
   - { state: latest, name: gnome-tweaks }
   - { state: latest, name: xorg-x11-server-Xorg }
   - { state: latest, name: xorg-x11-server-Xwayland }

--- a/vars/fedora-41.yml
+++ b/vars/fedora-41.yml
@@ -18,7 +18,7 @@ _service: gdm.service
 
 _yum:
   - { state: latest, name: "@gnome-desktop" }
-  - { state: latest, name: chrome-gnome-shell }
+  - { state: latest, name: gnome-browser-connector }
   - { state: latest, name: gnome-tweaks }
   - { state: latest, name: xorg-x11-server-Xorg }
   - { state: latest, name: xorg-x11-server-Xwayland }

--- a/vars/fedora-42.yml
+++ b/vars/fedora-42.yml
@@ -1,0 +1,24 @@
+---
+
+# Copyright 2025 Wong Hoi Sing Edison <hswong3i@pantarei-design.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_service: gdm.service
+
+_yum:
+  - { state: latest, name: "@gnome-desktop" }
+  - { state: latest, name: gnome-browser-connector }
+  - { state: latest, name: gnome-tweaks }
+  - { state: latest, name: xorg-x11-server-Xorg }
+  - { state: latest, name: xorg-x11-server-Xwayland }


### PR DESCRIPTION
The package `chrome-gnome-shell` was renamed to `gnome-browser-connector` beginning with Fedora 40.

This PR fixes the incorrect package name (see #1) and also adds variables for Fedora 42.